### PR TITLE
#513: Clear authenticator after invalid credentials

### DIFF
--- a/app/templates/node-server/utils/auth-helper.js
+++ b/app/templates/node-server/utils/auth-helper.js
@@ -82,6 +82,7 @@ function init() {
             //no user profile yet..
             done(null, user);
           } else if (response.statusCode === 401) {
+            clearAuthenticator(req.session);
             done(null, false, {
               message: 'Invalid credentials'
             });


### PR DESCRIPTION
Otherwise, the user has no ability to correct the login credentials.

This fixes #513 