### PR TITLE
Removing unused switchLogin code

### DIFF
--- a/app/templates/ui/app/login/login.service.js
+++ b/app/templates/ui/app/login/login.service.js
@@ -75,15 +75,6 @@
       }, failLogin);
     }
 
-    function switchLogin(username) {
-      return $http.post('/api/user/switch', {
-        'username': username
-      }).then(function(response) {
-        loginSuccess(response);
-        return response;
-      }, failLogin);
-    }
-
     function loginPrompt() {
       var d = $q.defer();
       if (_loginMode === 'modal') {
@@ -195,7 +186,6 @@
     angular.extend(service, {
       login: login,
       logout: logout,
-      switch: switchLogin,
       loginPrompt: loginPrompt,
       loginError: loginError,
       loginMode: loginMode,


### PR DESCRIPTION
It also refers to an '/api/user/switch' middle-tier route that doesn't
exist.

I can see how this code could be helpful, and might actually be in use in some demos, but it seems to rely on a middle-tier route that is not in the project. I suggest removing the dead code, as in this PR.

Alternatively, the middle-tier it anticipates could be added, after vetting that it doesn't raise security concerns.